### PR TITLE
fix: retry transient timeouts + add issues permission

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -16,16 +16,24 @@ jobs:
       - name: Trigger refresh
         id: refresh
         run: |
+          success=false
           for attempt in 1 2 3; do
             echo "Attempt $attempt..."
-            response=$(curl -sf "https://aibtc-projects.pages.dev/api/refresh?key=$REFRESH_KEY" \
+            if response=$(curl -sf "https://aibtc-projects.pages.dev/api/refresh?key=$REFRESH_KEY" \
               -H "User-Agent: github-actions-refresh" \
-              --max-time 90 2>&1) && break
+              --max-time 90 2>&1); then
+              success=true
+              break
+            fi
             echo "Attempt $attempt failed (exit $?), retrying in 5s..."
             sleep 5
           done
           echo "$response"
           echo "response=$response" >> "$GITHUB_OUTPUT"
+          if [ "$success" != "true" ]; then
+            echo "All 3 attempts failed"
+            exit 1
+          fi
         env:
           REFRESH_KEY: ${{ secrets.REFRESH_KEY }}
 

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -5,17 +5,25 @@ on:
     - cron: '*/15 * * * *'
   workflow_dispatch:
 
+permissions:
+  issues: write
+
 jobs:
   refresh:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 3
     steps:
       - name: Trigger refresh
         id: refresh
         run: |
-          response=$(curl -sf "https://aibtc-projects.pages.dev/api/refresh?key=$REFRESH_KEY" \
-            -H "User-Agent: github-actions-refresh" \
-            --max-time 90 2>&1)
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt..."
+            response=$(curl -sf "https://aibtc-projects.pages.dev/api/refresh?key=$REFRESH_KEY" \
+              -H "User-Agent: github-actions-refresh" \
+              --max-time 90 2>&1) && break
+            echo "Attempt $attempt failed (exit $?), retrying in 5s..."
+            sleep 5
+          done
           echo "$response"
           echo "response=$response" >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
## Summary
- Added retry loop (3 attempts, 5s delay) to the refresh curl step to handle intermittent timeouts (exit code 28)
- Added `permissions: issues: write` so the failure notification step can actually create GitHub issues (was getting 403 "Resource not accessible by integration")
- Bumped `timeout-minutes` from 2 to 3 to accommodate retries

## Context
The refresh endpoint at `aibtc-projects.pages.dev` occasionally takes >90s to respond, causing curl timeout failures. Out of the last 20 runs, 3 failed this way — with successful runs immediately before and after, confirming the issue is transient.

The "Create issue on failure" step was also broken — it lacked the `issues: write` permission, so every failure notification attempt returned a 403.

## Test plan
- [ ] Merge and monitor next few scheduled runs
- [ ] Manually trigger workflow via `workflow_dispatch` to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)