### PR TITLE
Add tsconfig.json with strict mode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*", "functions/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
Adds `tsconfig.json` with strict mode enabled at repo root.

## Changes
- `tsconfig.json`: ES2022 target, ESNext module, strict mode, bundler module resolution
- Includes `src/**/*` and `functions/**/*`
- Excludes `node_modules`

## Why
Fixes #41 - TypeScript configuration was missing, preventing strict type checking and proper IDE support.